### PR TITLE
This header don't need the ";"

### DIFF
--- a/add-cache-control-header/index.js
+++ b/add-cache-control-header/index.js
@@ -3,7 +3,7 @@ function handler(event) {
     var headers = response.headers;
     
     // Set the cache-control header
-     headers['cache-control'] = {value: 'public, max-age=63072000;'};
+     headers['cache-control'] = {value: 'public, max-age=63072000'};
         
     // Return response to viewers
     return response;


### PR DESCRIPTION
*Issue #, if available:* No issue

*Description of changes:*
Removed the ";" from the header, the page https://developers.google.com/speed/pagespeed/insights/ report that the cache is not enable if the ";" is there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
