### PR TITLE
Security headers recommended by Mozilla Observatory

### DIFF
--- a/add-security-headers/index.js
+++ b/add-security-headers/index.js
@@ -5,10 +5,11 @@ function handler(event) {
     // Set HTTP security headers
     // Since JavaScript doesn't allow for hyphens in variable names, we use the dict["key"] notation 
     headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload'}; 
-    headers['content-security-policy'] = { value: "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"}; 
+    headers['content-security-policy'] = { value: "default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'; frame-ancestors 'none'"}; 
     headers['x-content-type-options'] = { value: 'nosniff'}; 
     headers['x-frame-options'] = {value: 'DENY'}; 
-    headers['x-xss-protection'] = {value: '1; mode=block'}; 
+    headers['x-xss-protection'] = {value: '1; mode=block'};
+    headers['referrer-policy'] = {value: 'same-origin'};
     
     // Return the response to viewers 
     return response;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I suggest adding the following headers to make the headers set more robust:

- frame-ancestors (to CSP)
- referrer-policy


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
