### PR TITLE
Update README for add-true-client-ip-header function to not refer to X-Real-Ip.

### DIFF
--- a/add-true-client-ip-header/README.md
+++ b/add-true-client-ip-header/README.md
@@ -8,7 +8,7 @@
 
 **Note:**
 - You only need this header if your origin includes logic based on the client's IP address. If your origin returns the same content regardless of the client IP address, this function is likely not needed.
-- You don't have to use the header name `True-Client-IP`. You can change the name to any value that your origin requires (e.g. `X-Real-IP`).
+- You don't have to use the header name `True-Client-IP`. You can change the name to any value that your origin requires (e.g. `X-Real-Client-IP`).
 - CloudFront also sends an `X-Forwarded-For` header to your origin, which contains the client's IP address along with any HTTP proxies or load balancers that the request passed through.
 
 **Testing the function**


### PR DESCRIPTION
It isn't possible to use the suggested alternative header `X-Real-IP` for the "add-true-client-ip" function.

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html#add-origin-custom-headers-denylist

> Custom headers that CloudFront can’t add to origin requests
> You can’t configure CloudFront to add any of the following headers to requests that it sends to your origin:
> ...
> * X-Real-Ip