### PR TITLE
Add information about response headers policies

### DIFF
--- a/add-security-headers/README.md
+++ b/add-security-headers/README.md
@@ -1,5 +1,7 @@
 ## Add HTTP security headers
 
+> :warning: Consider using [CloudFront Response Headers Policies](https://aws.amazon.com/blogs/networking-and-content-delivery/amazon-cloudfront-introduces-response-headers-policies/) instead of CloudFront Functions to configure CORS, security, and custom HTTP response headers.
+
 **CloudFront Functions event type: viewer response**
 
 This function adds several common HTTP security headers to the response from CloudFront. The following headers are added as part of this function:


### PR DESCRIPTION
**Issue #, if available:** n/a

**Description of changes:**  Add notification that CloudFront Response Headers Policies should be considered instead of CloudFront Functions to configure CORS, security, and custom HTTP response headers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
