### PR TITLE
Redirect URI without trailing slash to fix broken HTML assets

### DIFF
--- a/url-rewrite-single-page-apps/index.js
+++ b/url-rewrite-single-page-apps/index.js
@@ -8,7 +8,14 @@ function handler(event) {
     } 
     // Check whether the URI is missing a file extension.
     else if (!uri.includes('.')) {
-        request.uri += '/index.html';
+        var response = {
+            statusCode: 302,
+            statusDescription: 'Moved Permanently',
+            headers: {
+               'location': { value: uri + '/' }
+            }
+        };
+        return response;
     }
 
     return request;


### PR DESCRIPTION
Original code has a slight issue that causes HTML assets to not load correctly.

Example: http://domain/subdir
- The function modifies the request to fetch http://domain/subdir/index.html
- The index.html refers to assets such as `<img src='image.png />`
- Browser attempts to fetch from http://domain/image.png rather than http://domain/subdir/image.png

By modifying the `else if` statement to perform a 302 redirect, and append a trailing slash, the next time our CloudWatch function is called, it will be handled by the first `if` statement, with the browser requesting HTML assets from the correct location, as the base url now has the trailing slash in place.