### PR TITLE
Update decode function

### DIFF
--- a/verify-jwt/index.js
+++ b/verify-jwt/index.js
@@ -80,7 +80,8 @@ function _sign(input, key, method) {
 }
 
 function _base64urlDecode(str) {
-    return String.bytesFrom(str, 'base64url')
+    return Buffer.from(str, 'base64url')    // for Runtime version cloudfront-js-2.0
+    // return String.bytesFrom(str, 'base64url')    // for Runtime version cloudfront-js-1.0
 }
 
 function handler(event) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
According to [AWS documentation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-javascript-runtime-features.html), it is recommended to use runtime version 2.0, so the examples should be oriented to this version.

The **String.bytesFrom()** method is not available in version 2.0. Instead, the **Buffer.from()** method should be used.

Also, the deprecated method **String.bytesFrom()** was commented out and left in the script for those who prefer to use the legacy runtime version 1.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
