### PR TITLE
Add example metadata to publish CloudFront Functions into documentation

### DIFF
--- a/.doc_gen/metadata/cloudfront-functions_metadata.yaml
+++ b/.doc_gen/metadata/cloudfront-functions_metadata.yaml
@@ -1,0 +1,188 @@
+cloudfront_functions_add_cache_control_header:
+  title: Add a cache control header to a &CF; Functions viewer response event
+  title_abbrev: Add a cache control header
+  synopsis: add a cache control header to a &CF; Functions viewer response event.
+
+  category: CloudFront Functions examples
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 102
+          github: https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/add-cache-control-header
+          excerpts:
+            - description:
+              snippet_files:
+                - add-cache-control-header/index.js
+  services:
+    cloudfront:
+cloudfront_functions_add_cors_header:
+  title: Add a CORS header to a &CF; Functions viewer response event
+  title_abbrev: Add a CORS header
+  synopsis: add a CORS header to a &CF; Functions viewer response event.
+
+  category: CloudFront Functions examples
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 102
+          github: https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/add-cors-header
+          excerpts:
+            - description:
+              snippet_files:
+                - add-cors-header/index.js
+  services:
+    cloudfront:
+cloudfront_functions_add_origin_header:
+  title: Add an origin header to a &CF; Functions viewer request event
+  title_abbrev: Add an origin header
+  synopsis: add an origin header to a &CF; Functions viewer request event.
+
+  category: CloudFront Functions examples
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 102
+          github: https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/add-origin-header
+          excerpts:
+            - description:
+              snippet_files:
+                - add-origin-header/index.js
+  services:
+    cloudfront:
+cloudfront_functions_add_security_headers:
+  title: Add HTTP security headers to a &CF; Functions viewer response event
+  title_abbrev: Add HTTP security headers
+  synopsis: add HTTP security headers to a &CF; Functions viewer response event.
+
+  category: CloudFront Functions examples
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 102
+          github: https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/add-security-headers
+          excerpts:
+            - description:
+              snippet_files:
+                - add-security-headers/index.js
+  services:
+    cloudfront:
+cloudfront_functions_add_true_client_ip_header:
+  title: Add a true client IP header to a &CF; Functions viewer request event
+  title_abbrev: Add a true client IP header
+  synopsis: add a true client IP header to a &CF; Functions viewer request event.
+
+  category: CloudFront Functions examples
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 102
+          github: https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/add-true-client-ip-header
+          excerpts:
+            - description:
+              snippet_files:
+                - add-true-client-ip-header/index.js
+  services:
+    cloudfront:
+cloudfront_functions_kvs_conditional_read:
+  title: Rewrite a request URI based on KeyValueStore configuration for a &CF; Functions viewer request event
+  title_abbrev: Rewrite a request URI
+  synopsis: rewrite a request URI based on KeyValueStore configuration for a &CF; Functions viewer request event.
+
+  category: CloudFront Functions examples
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 102
+          github: https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/kvs-conditional-read
+          excerpts:
+            - description:
+              snippet_files:
+                - kvs-conditional-read/ABUriMappingFunction.js
+  services:
+    cloudfront:
+cloudfront_functions_kvs_jwt_verify:
+  title: Validate a simple token in a &CF; Functions viewer request
+  title_abbrev: Validate a simple token
+  synopsis: validate a simple token in a &CF; Functions viewer request.
+
+  category: CloudFront Functions examples
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 102
+          github: https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/kvs-jwt-verify
+          excerpts:
+            - description:
+              snippet_files:
+                - kvs-jwt-verify/verify-jwt.js
+  services:
+    cloudfront:
+cloudfront_functions_kvs_key_value_pairs:
+  title: Use key-value pairs in a &CF; Functions viewer request
+  title_abbrev: Use key-value pairs
+  synopsis: use key-value pairs in a &CF; Functions viewer request.
+
+  category: CloudFront Functions examples
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 102
+          github: https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/kvs-key-value-pairs
+          excerpts:
+            - description:
+              snippet_files:
+                - kvs-key-value-pairs/kvs-key-value-pairs.js
+  services:
+    cloudfront:
+cloudfront_functions_normalize_query_string_parameters:
+  title: Normalize query string parameters in a &CF; Functions viewer request
+  title_abbrev: Normalize query string parameters
+  synopsis: normalize query string parameters in a &CF; Functions viewer request.
+
+  category: CloudFront Functions examples
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 102
+          github: https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/normalize-query-string-parameters
+          excerpts:
+            - description:
+              snippet_files:
+                - normalize-query-string-parameters/normalize-query-string.js
+  services:
+    cloudfront:
+cloudfront_functions_redirect_based_on_country:
+  title: Redirect to a new URL in a &CF; Functions viewer request event
+  title_abbrev: Redirect to a new URL
+  synopsis: redirect to a new URL in a &CF; Functions viewer request event.
+
+  category: CloudFront Functions examples
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 102
+          github: https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/redirect-based-on-country
+          excerpts:
+            - description:
+              snippet_files:
+                - redirect-based-on-country/index.js
+  services:
+    cloudfront:
+cloudfront_functions_url_rewrite_single_page_apps:
+  title: Add index.html to request URLs without a file name in a &CF; Functions viewer request event
+  title_abbrev: Add index.html to request URLs
+  synopsis: add index.html to request URLs without a file name in a &CF; Functions viewer request event.
+
+  category: CloudFront Functions examples
+  languages:
+    JavaScript:
+      versions:
+        - sdk_version: 102
+          github: https://github.com/aws-samples/amazon-cloudfront-functions/tree/main/url-rewrite-single-page-apps
+          excerpts:
+            - description:
+              snippet_files:
+                - url-rewrite-single-page-apps/index.js
+  services:
+    cloudfront:
+


### PR DESCRIPTION
This PR adds the necessary metadata to let this repository function as a code example tributary.

After this PR is merged, the backend system can be configured to start publishing CloudFront Functions code snippets into AWS documentation. Once the backend is configured, subsequent updates to code examples in this tributary will flow through into the documentation through an automated build process.

* The JavaScript `sdk_version` field of `102` is equivalent to "JavaScript runtime 2.0 for CloudFront Functions" a `101` version is also available for tagging examples as runtime 1.0, if needed.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
